### PR TITLE
When calling resample_to_1s from menu, the map widget do not refresh …

### DIFF
--- a/widgets/gpx_control_widget.py
+++ b/widgets/gpx_control_widget.py
@@ -3116,6 +3116,8 @@ class GPXControlWidget(QWidget):
         mw._gpx_data = new_data
         mw.gpx_widget.set_gpx_data(new_data)
         mw._update_gpx_overview()
+        route_geojson = mw._build_route_geojson_from_gpx(new_data)
+        mw.map_widget.loadRoute(route_geojson, do_fit=False)
         mw.chart.set_gpx_data(new_data)
         if mw.mini_chart_widget:
             mw.mini_chart_widget.set_gpx_data(new_data)


### PR DESCRIPTION
Reproducing the bug:
1. open a 3s frequency gpx.
2. from menu resample it to 1s interval
3. you still see the old points on the map and the video moving the points on the old path (going 3 times faster than it should in this case)


With this simple call this is fixed.